### PR TITLE
Replace deprecated comment syntax

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,6 +1,6 @@
 {
   "comments": {
-    "blockComment": ["<%#", "%>"]
+    "blockComment": ["<%!--", "--%>"]
   },
   "brackets": [
     ["<", ">"],


### PR DESCRIPTION
From https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.HTMLFormatter.html:

> Inline comments `<%# comment %>` are deprecated and the formatter will discard them silently from templates. You must change them to the multi-line comment `<%!-- comment --%>` on Elixir v1.14+ or the regular line comment `<%= # comment %>`.