### PR TITLE
Fix commenting feature in H sigils

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,10 @@
                 "path": "./syntaxes/elixir-heex.json",
                 "injectTo": [
                     "source.elixir"
-                ]
+                ],
+                "embeddedLanguages": {
+                    "text.html.heex": "phoenix-heex"
+                }
             }
         ]
     }


### PR DESCRIPTION
### Problem

Commenting in `*.heex` files works as expected with `<%!-- ... --%>` tokens introduced by #14.

In H sigils though, commenting does not work because code is considered as classic Elixir code (`# ...` token is used).

[commenting_issue_in_h_sigils.webm](https://user-images.githubusercontent.com/24209524/193893609-c5fb94d0-d161-4af6-8482-696df3011b19.webm)


### Solution

Make VSCode consider code inside H sigils as `phoenix-heex` language, leveraging the [`embeddedLanguages` feature](https://code.visualstudio.com/api/language-extensions/syntax-highlight-guide#embedded-languages).

[commenting_issue_in_h_sigils_solved.webm](https://user-images.githubusercontent.com/24209524/193894161-47be911a-e94a-4c25-81bc-4b8963bfe122.webm)

