### PR TITLE
Fix syntax highlighting in comments

### DIFF
--- a/syntaxes/heex.json
+++ b/syntaxes/heex.json
@@ -12,7 +12,13 @@
       "include": "#html-comment"
     },
     {
+      "include": "#deprecated-heex-comment"
+    },
+    {
       "include": "#heex-comment"
+    },
+    {
+      "include": "#heex-multi-line-comment"
     },
     {
       "include": "#elixir-embedded"
@@ -85,7 +91,7 @@
         }
       ]
     },
-    "heex-comment": {
+    "deprecated-heex-comment": {
       "begin": "<%+#",
       "captures": {
         "0": {
@@ -93,6 +99,26 @@
         }
       },
       "end": "%>",
+      "name": "comment.block.heex"
+    },
+    "heex-comment": {
+      "begin": "<%+ #",
+      "captures": {
+        "0": {
+          "name": "punctuation.definition.comment.heex"
+        }
+      },
+      "end": "%>",
+      "name": "comment.block.heex"
+    },
+    "heex-multi-line-comment": {
+      "begin": "<%+!--",
+      "captures": {
+        "0": {
+          "name": "punctuation.definition.comment.heex"
+        }
+      },
+      "end": "--%>",
       "name": "comment.block.heex"
     },
     "elixir-embedded": {


### PR DESCRIPTION
### Problem

Syntax highlighting does not work:

1. for new comments syntax `<%!-- ... --%>`
2. for comments syntax `<% # ... %>`, which is highlighted as embedded elixir instead of heex comment 

[comments_syntax_issue.webm](https://user-images.githubusercontent.com/24209524/193896987-9398a21c-9ce6-4a65-b01b-a1ddda3b5f4f.webm)

See https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.HTMLFormatter.html#module-inline-comments-comment.

### Solution

[comments_syntax_issue_solved.webm](https://user-images.githubusercontent.com/24209524/193896691-a406c0a8-000f-43c2-8dbe-57135728c5f6.webm)
