### PR TITLE
Opt into html language features

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,13 +8,18 @@
     "publisher": "phoenixframework",
     "license": "MIT",
     "icon": "images/logo.png",
+    "main": "./src/extension.js",
+    "activationEvents": [],
     "repository": {
         "type": "git",
         "url": "https://github.com/phoenixframework/vscode-phoenix.git"
     },
     "engines": {
-        "vscode": "^1.25.1"
+        "vscode": "^1.75.0"
     },
+    "extensionDependencies": [
+	    "vscode.html-language-features"
+    ],
     "categories": [
         "Programming Languages"
     ],
@@ -30,6 +35,12 @@
                     ".heex"
                 ],
                 "configuration": "./language-configuration.json"
+            }
+        ],
+        "htmlLanguageParticipants": [
+            {
+                "languageId": "phoenix-heex",
+                "autoInsert": true
             }
         ],
         "grammars": [


### PR DESCRIPTION
This opts into VSCode's built-in HTML language features, allowing for autocomplete and documentation based on HTML tags, attributes, etc.

Addresses #20 and #18.

The extension.js implementation is cribbed directly from[ Jinja's implementation](https://github.com/samuelcolvin/jinjahtml-vscode/pull/118) to address https://github.com/microsoft/vscode/issues/160585 as mentioned in the comment.