### PR TITLE
Fix HEEx sigil syntax highlighting in functions

### DIFF
--- a/syntaxes/elixir-heex.json
+++ b/syntaxes/elixir-heex.json
@@ -11,7 +11,7 @@
           "name": "string.quoted.double.heredoc.elixir"
         }
       },
-      "end": "^\\s*(\"\"\"[a-z]*)$",
+      "end": "^\\s*(\"\"\"[a-z]*)",
       "endCaptures": {
         "0": {
           "name": "string.quoted.double.heredoc.elixir"


### PR DESCRIPTION
The existing regex prevented the end of a HEEx sigil from being detected if the line had any additional content after the `"""[modifiers]`. This caused highlighting to break if a HEEx sigil was ever passed into a function as `""")` or `""", :more_args)` would not be detected by the regex.

Closes #7 