### PR TITLE
Syntax highlighting for curly brackets on heex

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,16 @@
+{
+  "name": "phoenix",
+  "version": "0.1.3",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "phoenix",
+      "version": "0.1.3",
+      "license": "MIT",
+      "engines": {
+        "vscode": "^1.25.1"
+      }
+    }
+  }
+}

--- a/syntaxes/heex.json
+++ b/syntaxes/heex.json
@@ -1,9 +1,7 @@
 {
   "name": "heex",
   "scopeName": "source.heex",
-  "fileTypes": [
-    "heex"
-  ],
+  "fileTypes": ["heex"],
   "patterns": [
     {
       "include": "#doctype"
@@ -22,6 +20,9 @@
     },
     {
       "include": "#elixir-embedded"
+    },
+    {
+      "include": "#elixir-curly-embedded"
     },
     {
       "include": "#slotable"
@@ -138,6 +139,30 @@
             }
           },
           "match": "(#).*?(?=-?%>)",
+          "name": "comment.line.number-sign.elixir"
+        },
+        {
+          "include": "source.elixir"
+        }
+      ]
+    },
+    "elixir-curly-embedded": {
+      "begin": "\\{",
+      "captures": {
+        "0": {
+          "name": "punctuation.section.embedded.elixir"
+        }
+      },
+      "end": "\\}",
+      "name": "source.elixir.embedded",
+      "patterns": [
+        {
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.comment.elixir"
+            }
+          },
+          "match": "(#).*?(?=\\})",
           "name": "comment.line.number-sign.elixir"
         },
         {


### PR DESCRIPTION
I've forked this repo to get syntax highlight working with the newly added curly brackets syntax.
I'm not sure if this is the way to submit a possible contribution, and it definitely needs revision.
